### PR TITLE
Update wwtcanvas width to match description box

### DIFF
--- a/content/style.css
+++ b/content/style.css
@@ -166,7 +166,7 @@ a, a:hover {
 /* WWT canvas */
 
 #wwtcanvas {
-	width: 90%;  /* note: overridden in SSE_script.js */
+	width: 99%;  /* note: overridden in SSE_script.js */
 	height: 100%;  /* note: overridden in SSE_script.js */
 	margin: auto;
 	border: solid 1px #333;


### PR DESCRIPTION
- For some reason, when you set wwtcanvas width to 100%, it does not resize correctly when you reduce the browser window size. Making it 99% works fine and you can barely tell it isn't the same width as the description box.